### PR TITLE
copy: tune back specific Praxis references — runtime not yet shipping

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -1,4 +1,4 @@
 ---
 title: "Getting Started"
-description: "How to go from browsing PAX on pax-market.com to running Praxis on your own infrastructure"
+description: "How to go from browsing PAX on pax-market.com to using verified knowledge in your own work"
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -8,7 +8,6 @@ theme = 'pax-terminal'
   tagline = 'Portable Analytical eXpertise'
   github_url = 'https://github.com/JELambert/pax-website'
   registry_url = 'https://github.com/JELambert/pax-market'
-  praxis_url = 'https://github.com/JELambert/praxis'
 
 [taxonomies]
   tag = 'tags'

--- a/themes/pax-terminal/layouts/about/list.html
+++ b/themes/pax-terminal/layouts/about/list.html
@@ -66,7 +66,7 @@
       <div class="t-principle">
         <div class="t-principle-number">06</div>
         <div class="t-principle-title">Built for agents</div>
-        <p class="t-principle-body">Praxis MCP server provides the runtime. Agents call get, search, query, align — and reason over your pax like a research assistant.</p>
+        <p class="t-principle-body">An MCP-server runtime <em>(coming soon)</em> will let agents query, align, and reason over your pax like a research assistant.</p>
       </div>
     </div>
   </div>

--- a/themes/pax-terminal/layouts/getting-started/list.html
+++ b/themes/pax-terminal/layouts/getting-started/list.html
@@ -4,7 +4,7 @@
 <header class="t-gs-header">
   <div class="t-caption">// start/</div>
   <h1 class="t-gs-title">Two ways to use Pax</h1>
-  <p class="t-gs-lede">Pick the tier that matches how you want to consume verified knowledge. Tier 1 needs no tooling. Tier 2 hands pax to an agent via the Praxis MCP server.</p>
+  <p class="t-gs-lede">Pick the tier that matches how you want to consume verified knowledge. Tier 1 needs no tooling and works today. Tier 2 — agentic access via an MCP-server runtime — is coming soon.</p>
 
   {{- /* ── Tier tab nav ───────────────────────────────────────────────── */ -}}
   <nav class="t-gs-tabs" id="tier-tabs">
@@ -107,95 +107,17 @@ network given:
   </div>
 </section>
 
-{{- /* ── Tier 2 (was Tier 3): MCP server via Praxis ──────────────────── */ -}}
+{{- /* ── Tier 2: agentic access (coming soon) ───────────────────────── */ -}}
 <section class="t-gs-panel" id="tier-3">
   <div class="t-gs-panel-inner">
     <div class="t-gs-panel-left">
-      {{ partial "section-head.html" (dict "caption" "tier.02 · agentic" "title" "MCP server (Praxis)") }}
-      <p class="t-gs-body-lede">Run Pax inside any MCP-compatible agent (Claude Code, Continue, Zed, Cursor) via <a href="https://github.com/JELambert/praxis" target="_blank" rel="noopener" class="t-link">Praxis</a>, the reference MCP server for the pax format. Tools like <code>praxis_search_pax</code>, <code>praxis_install_pax</code>, <code>praxis_query_findings</code> become first-class.</p>
+      {{ partial "section-head.html" (dict "caption" "tier.02 · agentic" "title" "MCP-server runtime") }}
+      <p class="t-gs-body-lede">An MCP-server runtime is in development. It will let any MCP-compatible agent (Claude Code, Continue, Zed, Cursor) load a pax, query its findings and constructs, align constructs across pax, and run registered analytical playbooks — turning the static knowledge layer here into a live agentic surface.</p>
 
-      <div class="t-gs-sub">
-        {{ partial "section-head.html" (dict "caption" "install" "title" "Run Praxis locally") }}
-        <p style="font-family:'Source Serif 4','Source Serif Pro',Georgia,serif; font-size:14px; line-height:1.55; color:var(--pt-dim); margin:0 0 12px;">
-          Praxis is an open-source Python MCP server. Clone, install, and point your agent at it. Setup instructions live in the
-          <a href="https://github.com/JELambert/praxis" target="_blank" rel="noopener" class="t-link">Praxis README</a>.
+      <div class="t-gs-sub" style="margin-top: 18px;">
+        <p style="font-family:'Source Serif 4','Source Serif Pro',Georgia,serif; font-size:14px; line-height:1.6; color:var(--pt-dim); margin:0;">
+          <strong style="color:var(--pt-ink); font-style:normal;">Coming soon.</strong> Until then, Tier 1 (paste a pax into your model of choice) is the supported path. Pax authored today will work unchanged with the runtime when it ships — the format is the contract, the runtime is just one consumer.
         </p>
-      </div>
-
-      <div class="t-gs-sub">
-        {{ partial "section-head.html" (dict "caption" "exposed tools" "title" "Tool reference") }}
-        <div class="t-gs-tool-grid">
-          <div class="t-gs-tool-header">
-            <span>tool</span>
-            <span>signature</span>
-            <span>description</span>
-          </div>
-          <div class="t-gs-tool-row">
-            <span class="t-gs-tool-name">praxis_search_pax</span>
-            <span class="t-gs-tool-sig">(query: str)</span>
-            <span class="t-gs-tool-desc">search the registry by keyword</span>
-          </div>
-          <div class="t-gs-tool-row">
-            <span class="t-gs-tool-name">praxis_install_pax</span>
-            <span class="t-gs-tool-sig">(pax: str)</span>
-            <span class="t-gs-tool-desc">download and install a pax locally</span>
-          </div>
-          <div class="t-gs-tool-row">
-            <span class="t-gs-tool-name">praxis_query_findings</span>
-            <span class="t-gs-tool-sig">(construct: str, pax?: str)</span>
-            <span class="t-gs-tool-desc">retrieve findings for a construct</span>
-          </div>
-          <div class="t-gs-tool-row">
-            <span class="t-gs-tool-name">praxis_query_constructs</span>
-            <span class="t-gs-tool-sig">(pax?: str)</span>
-            <span class="t-gs-tool-desc">list and search constructs across pax</span>
-          </div>
-          <div class="t-gs-tool-row">
-            <span class="t-gs-tool-name">praxis_align_constructs</span>
-            <span class="t-gs-tool-sig">(pax_a: str, pax_b: str)</span>
-            <span class="t-gs-tool-desc">find bridge constructs between two pax</span>
-          </div>
-          <div class="t-gs-tool-row">
-            <span class="t-gs-tool-name">praxis_run_playbook</span>
-            <span class="t-gs-tool-sig">(pax: str, playbook: str)</span>
-            <span class="t-gs-tool-desc">execute an analytical playbook</span>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="t-gs-panel-right">
-      {{ partial "section-head.html" (dict "caption" "end-to-end" "title" "A worked example" "kicker" "From English request to a cited result.") }}
-      <div class="t-code-block" style="max-height:620px; overflow-y:auto;">
-        <div class="t-code-block-bar"><span>text &middot; agent transcript</span></div>
-        <pre id="t-code-gs-mcp-transcript">USER  &gt; using the supply-chain pax, identify our top
-        cascading-failure risks. cite findings.
-
-CLAUDE &gt; [tool] praxis_install_pax
-       ↳ { pax: 'global-supply-chain-risk' }
-         38 constructs, 113 findings, 8 playbooks
-
-       [tool] praxis_query_findings
-              { construct: 'cascading_failure_size' }
-       ↳ 8 findings · sorted by strength
-
-       [tool] praxis_query_findings
-              { ids: ['F001', 'F003', 'F005'] }
-       ↳ F001: -40% equity returns on disruption
-         F003: top-5% nodes → 64% of cascades
-         F005: Malacca blockage $9.6B/day
-
-──────── results ────────
-Three nodes carry disproportionate risk:
-  1) Supplier_A (betweenness 0.41) — F003: TSMC-style
-     concentration; one outage propagates to 64% of
-     downstream tier-2 nodes.
-  2) Supplier_C (TTR/TTS = 3.1) — F001: REI > 1
-     historically associates with -40% equity returns.
-  3) Chokepoint_K (Strait of Malacca) — F005: 6-day
-     blockage modeled at $9.6B/day in delayed trade.
-
-cited: F001, F003, F005, P001.</pre>
       </div>
     </div>
   </div>

--- a/themes/pax-terminal/layouts/guide/list.html
+++ b/themes/pax-terminal/layouts/guide/list.html
@@ -251,9 +251,9 @@
       {{/* 11. publishing */}}
       <section id="section-11" class="t-guide-section">
         {{ partial "section-head.html" (dict "caption" "11.publishing" "title" "Publishing") }}
-        <p class="t-guide-prose">There are two paths to publishing a pax: the web uploader, or directly through Praxis. Both paths run the same registry validation before merging.</p>
+        <p class="t-guide-prose">Publish a pax through the web uploader. Validation runs against the same registry contract whether you submit by hand today or through the agentic path that's coming later.</p>
 
-        <div class="t-guide-subsection-head">path 1 — web upload</div>
+        <div class="t-guide-subsection-head">web upload</div>
         <ol class="t-guide-ol">
           <li>Zip your pax directory: <code class="t-inline-code">zip -r my-pax.zip my-pax-name/</code></li>
           <li>Upload at <a href="https://submit.pax-market.com" class="t-guide-link">submit.pax-market.com</a>.</li>
@@ -261,11 +261,10 @@
           <li>After editorial review, your pax is merged and live within minutes.</li>
         </ol>
 
-        <div class="t-guide-subsection-head">path 2 — publish through praxis</div>
-        <p class="t-guide-prose">If you already use the <a href="https://github.com/JELambert/praxis" target="_blank" rel="noopener" class="t-guide-link">Praxis MCP server</a>, you can author and publish from inside any MCP-aware agent (Claude Code, Continue, Zed, Cursor). The agent calls <code class="t-inline-code">praxis_publish_pax</code> with your pax folder; Praxis handles the validation and submission to the registry on your behalf.</p>
-        {{ partial "code-block.html" (dict "lang" "agent · MCP tool call" "id" "publish-praxis-ex" "code" "praxis_publish_pax(\n  path=\"./my-pax-name\",\n  message=\"Initial release\"\n)\n\n→ validating schema...      ok\n→ resolving DOIs...         47/47 ok\n→ checking construct ids... no collisions\n→ submitted to pax-market   pr #142") }}
+        <p class="t-guide-prose">Once accepted, your pax appears at <code class="t-inline-code">pax-market.com/pax/my-pax-name</code> immediately after deploy.</p>
 
-        <p class="t-guide-prose">Either path lands at the same place: once accepted, your pax appears at <code class="t-inline-code">pax-market.com/pax/my-pax-name</code> immediately after deploy.</p>
+        <div class="t-guide-subsection-head">agentic publishing — coming soon</div>
+        <p class="t-guide-prose">An MCP-server runtime will let agents author and publish from inside any MCP-aware client. The submission contract is the same as the web path, so anything you author today will work unchanged when the agentic path ships.</p>
       </section>
 
     </div>{{/* end .t-guide-body */}}
@@ -278,7 +277,6 @@
           <li><a href="https://github.com/JELambert/pax-market" target="_blank" rel="noopener" class="t-guide-ref-link">[ ] pax-market/registry</a></li>
           <li><a href="https://github.com/JELambert/pax-market/blob/main/schema.json" target="_blank" rel="noopener" class="t-guide-ref-link">[ ] schema.json</a></li>
           <li><a href="/guide/#section-10" class="t-guide-ref-link">[ ] versioning guide</a></li>
-          <li><a href="https://github.com/JELambert/praxis" target="_blank" rel="noopener" class="t-guide-ref-link">[ ] praxis (mcp server)</a></li>
           <li><a href="https://submit.pax-market.com" target="_blank" rel="noopener" class="t-guide-ref-link">[ ] submit a pax</a></li>
         </ul>
 


### PR DESCRIPTION
Praxis is being held back from this open-source wave (only pax-website + pax-market shipping). Removes detailed Praxis specifics that imply a shipping product, while keeping the high-level pitch (MCP-server runtime that lets agents work with pax).

## Changes

- **about** — principle 06 softened from \"Praxis MCP server provides the runtime. Agents call get, search, query, align\" → \"An MCP-server runtime (coming soon) will let agents query, align, and reason over your pax\"
- **getting-started** — Tier 2 lede marked coming soon. Tier 2 panel replaces install instructions, 6-row tool-reference grid, and worked transcript with a placeholder noting Tier 1 is the supported path today and the format contract carries forward
- **guide** — Publishing collapses to a single web-upload path. Removed Path 2 with \`praxis_publish_pax\` example. Added a \"agentic publishing — coming soon\" subsection. Praxis repo link removed from sidebar references
- **getting-started front-matter** — description rewords away from \"running Praxis on your own infrastructure\"
- **hugo.toml** — drops \`praxis_url\` param (was set but never referenced — dead config)

## Out of scope

- **Showcase story 03** — left as-is per explicit scoping decision; the agentic transcript stays
- **Per-pack pages** (\`content/pax/*\`) — generated from full-catalog.json. The only Praxis reference is \`published_by: Praxis Agent\` which is already tracked as pax-market#67 (community-attribution bug)

## Test plan

- [x] Hugo build passes
- [x] \`grep -nE \"praxis|Praxis\"\` across the touched user-facing files returns nothing
- [ ] Visual check at localhost:1313 — about, /getting-started (both tiers), /guide section 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)