### PR TITLE
fix: drop author from /pax/ list version column

### DIFF
--- a/themes/pax-terminal/layouts/pax/list.html
+++ b/themes/pax-terminal/layouts/pax/list.html
@@ -73,9 +73,8 @@
         <div class="t-pax-tagline">{{ $p.Params.description | default "" | truncate 100 }}</div>
       </div>
 
-      {{/* Col 4: author / version */}}
+      {{/* Col 4: version */}}
       <div class="t-pax-author">
-        {{ with $p.Params.author }}<div>{{ . }}</div>{{ end }}
         <div>v{{ $p.Params.version | default "1.0.0" }}</div>
       </div>
 


### PR DESCRIPTION
## Summary
- The /pax/ list rendered both `author` and `version` under a column labeled VERSION
- Paper-type packs populate `author` with the source paper's full author list (e.g., "Batista, Catia; Han, Daniel; Haushofer, Johannes; ..."), causing tall stacked rows
- Drop `author` from the list view; it stays on the single pack page

Author-field semantics (pack maintainer vs. source authors) are a separate upstream question — tracked in pax-market.

## Test plan
- [ ] hugo --minify builds clean
- [ ] /pax/ list rows no longer show author lines under VERSION
- [ ] Single pack pages still display author info

🤖 Generated with [Claude Code](https://claude.com/claude-code)