### PR TITLE
fix(ci): authenticate GitHub API calls in fetch-artifacts.sh

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Fetch registry artifacts
         run: bash scripts/fetch-artifacts.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Hugo content from catalog
         run: python3 scripts/generate-content.py

--- a/scripts/fetch-artifacts.sh
+++ b/scripts/fetch-artifacts.sh
@@ -20,8 +20,14 @@ echo "Fetching latest registry artifacts from $REPO..."
 
 mkdir -p "$ARTIFACTS_DIR" "$STATIC_PAX_DIR"
 
-# Get download URLs from the latest release
-RELEASE_JSON=$(curl -sL "https://api.github.com/repos/$REPO/releases/latest")
+# Get download URLs from the latest release.
+# Use GITHUB_TOKEN when present to avoid the 60/hr unauthenticated rate limit
+# (shared runner IPs get exhausted quickly).
+AUTH_ARGS=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    AUTH_ARGS=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+RELEASE_JSON=$(curl -sL "${AUTH_ARGS[@]}" "https://api.github.com/repos/$REPO/releases/latest")
 if echo "$RELEASE_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'assets' in d" 2>/dev/null; then
     URLS=$(echo "$RELEASE_JSON" | python3 -c "
 import sys, json


### PR DESCRIPTION
## Summary
- Build Verify on main (#22 / fa58468) failed with HTTP 403 from `api.github.com/repos/JELambert/pax-market/releases/latest` — the shared runner IP hit the 60/hr unauthenticated rate limit.
- `fetch-artifacts.sh` now sends `Authorization: Bearer $GITHUB_TOKEN` when the env var is present (5000/hr authenticated).
- `build-verify.yml` injects `secrets.GITHUB_TOKEN` into the Fetch step.

Local runs without the token still work — the auth header is only added when `GITHUB_TOKEN` is set.

## Test plan
- [ ] CI Build Verify passes on this branch
- [ ] Confirm the fetch step in the run logs shows `200` for the releases/latest call (or simply that artifacts download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)