### PR TITLE
feat(guide): surface schema version + What's New from creation guide

### DIFF
--- a/scripts/generate-content.py
+++ b/scripts/generate-content.py
@@ -513,6 +513,67 @@ def generate_graph(packs: list, constructs: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Guide metadata extraction (parses PAX_CREATION_GUIDE.md)
+# ---------------------------------------------------------------------------
+
+def parse_guide_meta(guide_path: Path, packs: list) -> dict:
+    """Extract schema version, last-updated date, and 'What's New' bullets
+    from PAX_CREATION_GUIDE.md so the website can surface spec status without
+    duplicating the canonical text.
+    """
+    text = guide_path.read_text()
+
+    schema_version = ""
+    last_updated = ""
+    m = re.search(
+        r"\*\*Schema version:\*\*\s*([^\s—-]+)\s*[—-]\s*Last updated:\s*([0-9]{4}-[0-9]{2}-[0-9]{2})",
+        text,
+    )
+    if m:
+        schema_version = m.group(1).strip()
+        last_updated = m.group(2).strip()
+
+    # Pull "What's New in vX" bullets — each one starts "- **Title.** body"
+    whats_new = []
+    section = re.search(r"^## What's New[^\n]*\n(.*?)(?=^## )", text, re.MULTILINE | re.DOTALL)
+    if section:
+        for line in section.group(1).splitlines():
+            line = line.strip()
+            if not line.startswith("- "):
+                continue
+            body = line[2:]
+            bm = re.match(r"\*\*(.+?)\.\*\*\s*(.*)", body)
+            if bm:
+                whats_new.append({"title": bm.group(1).strip(), "description": bm.group(2).strip()})
+            else:
+                whats_new.append({"title": "", "description": body})
+
+    # Per-schema-version pack counts so the guide can show adoption at a glance.
+    distribution: dict[str, int] = {}
+    for p in packs:
+        sv = str(p.get("pax_schema_version") or "unknown")
+        distribution[sv] = distribution.get(sv, 0) + 1
+
+    return {
+        "schema_version": schema_version,
+        "last_updated": last_updated,
+        "whats_new": whats_new,
+        "pack_schema_distribution": distribution,
+        "total_packs": len(packs),
+    }
+
+
+def write_guide_meta(meta: dict):
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    out = DATA_DIR / "guide_meta.yml"
+    out.write_text(yaml.dump(meta, default_flow_style=False, allow_unicode=True, sort_keys=False))
+    print(
+        f"Wrote guide_meta.yml: schema {meta['schema_version']} ({meta['last_updated']}), "
+        f"{len(meta['whats_new'])} highlights, distribution {meta['pack_schema_distribution']}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -604,6 +665,15 @@ def main():
         print(f"Copied {count} archives -> static/pax/")
     else:
         print(f"WARNING: {artifacts_pax} not found, no archives copied", file=sys.stderr)
+
+    # Extract guide metadata from PAX_CREATION_GUIDE.md so the /guide/ page can
+    # show schema version, last-updated date, and "What's New" highlights
+    # without duplicating the canonical guide.
+    guide_path = ARTIFACTS_DIR / "PAX_CREATION_GUIDE.md"
+    if guide_path.exists():
+        write_guide_meta(parse_guide_meta(guide_path, packs))
+    else:
+        print(f"WARNING: {guide_path} not found, skipping guide_meta", file=sys.stderr)
 
     # Generate knowledge graph (Wave 20)
     constructs_for_graph_path = DATA_DIR / "constructs.json"

--- a/themes/pax-terminal/assets/css/terminal.css
+++ b/themes/pax-terminal/assets/css/terminal.css
@@ -2086,6 +2086,18 @@ button {
   color: var(--pt-ink);
 }
 
+.t-pax-schema-chip {
+  display: inline-block;
+  margin-top: 3px;
+  padding: 1px 6px;
+  border: 1px solid var(--pt-line);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  color: var(--pt-dim);
+  text-transform: lowercase;
+}
+
 .t-pax-counts {
   display: flex;
   gap: 12px;
@@ -4353,6 +4365,99 @@ button {
   gap: 16px;
   flex-wrap: wrap;
 }
+
+/* ── Spec status callout (rendered from data/guide_meta.yml) ─────── */
+.t-spec-status {
+  border: 1px solid var(--pt-line);
+  border-left: 3px solid var(--term-accent);
+  padding: 16px 20px;
+  margin-bottom: 18px;
+  background: var(--pt-panel);
+}
+.t-spec-status-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.t-spec-status-version {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--pt-ink);
+  margin-top: 2px;
+}
+.t-spec-status-date {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--pt-dim);
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+.t-spec-status-dist-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.t-spec-status-dist-cell {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 1px solid var(--pt-line);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.t-spec-status-dist-ver { color: var(--pt-dim); }
+.t-spec-status-dist-count { color: var(--pt-ink); font-weight: 600; }
+.t-spec-status-news { margin-top: 6px; }
+.t-spec-status-news > summary {
+  cursor: pointer;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--pt-ink);
+  letter-spacing: 0.04em;
+  padding: 4px 0;
+  list-style: none;
+}
+.t-spec-status-news > summary::before {
+  content: "▸ ";
+  color: var(--term-accent);
+}
+.t-spec-status-news[open] > summary::before { content: "▾ "; }
+.t-spec-status-news-count { color: var(--pt-dim); font-weight: 400; }
+.t-spec-status-news-list {
+  list-style: none;
+  padding: 8px 0 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.t-spec-status-news-list li {
+  font-family: 'Source Serif 4', 'Source Serif Pro', Georgia, serif;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--pt-dim);
+  padding-left: 12px;
+  border-left: 2px solid var(--pt-line);
+}
+.t-spec-status-news-list li strong {
+  color: var(--pt-ink);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+.t-spec-status-news-footer {
+  margin-top: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--pt-dim);
+}
+.t-spec-status-news-footer a { color: var(--term-accent); }
 
 .t-guide-dl-strip-copy {
   font-family: 'Source Serif 4', 'Source Serif Pro', Georgia, serif;

--- a/themes/pax-terminal/layouts/guide/list.html
+++ b/themes/pax-terminal/layouts/guide/list.html
@@ -14,6 +14,43 @@
     </div>
   </div>
 
+  {{/* ── Spec status (auto-extracted from PAX_CREATION_GUIDE.md) ─────── */}}
+  {{ $meta := site.Data.guide_meta }}
+  {{ if and $meta $meta.schema_version }}
+  <section class="t-spec-status" aria-label="Spec status">
+    <div class="t-spec-status-head">
+      <div>
+        <div class="t-caption">// spec/status</div>
+        <div class="t-spec-status-version">PAX schema {{ $meta.schema_version }}</div>
+        {{ with $meta.last_updated }}<div class="t-spec-status-date">last updated {{ . }}</div>{{ end }}
+      </div>
+      {{ with $meta.pack_schema_distribution }}
+      <div class="t-spec-status-dist" title="Pack count by schema version">
+        <div class="t-caption" style="margin-bottom:4px;">// registry mix</div>
+        <div class="t-spec-status-dist-row">
+          {{ range $ver, $count := . }}
+            <span class="t-spec-status-dist-cell"><span class="t-spec-status-dist-ver">v{{ $ver }}</span><span class="t-spec-status-dist-count">{{ $count }}</span></span>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+    </div>
+    {{ with $meta.whats_new }}
+    <details class="t-spec-status-news" open>
+      <summary>What's new in v{{ $meta.schema_version }} <span class="t-spec-status-news-count">({{ len . }})</span></summary>
+      <ul class="t-spec-status-news-list">
+        {{ range . }}
+        <li>{{ with .title }}<strong>{{ . | markdownify }}.</strong> {{ end }}{{ .description | markdownify }}</li>
+        {{ end }}
+      </ul>
+      <div class="t-spec-status-news-footer">
+        Full text in the <a href="/PAX_CREATION_GUIDE.md" download>creation guide</a> · "What's New" section.
+      </div>
+    </details>
+    {{ end }}
+  </section>
+  {{ end }}
+
   {{/* ── Guide download callout ───────────────────────────────────────── */}}
   <div class="t-guide-dl-strip">
     <p class="t-guide-dl-strip-copy">Hand these to Claude, ChatGPT, or Gemini and you can author or use a pax without any local tooling.</p>

--- a/themes/pax-terminal/layouts/pax/list.html
+++ b/themes/pax-terminal/layouts/pax/list.html
@@ -76,6 +76,7 @@
       {{/* Col 4: version */}}
       <div class="t-pax-author">
         <div>v{{ $p.Params.version | default "1.0.0" }}</div>
+        {{ with $p.Params.pax_schema_version }}<div class="t-pax-schema-chip" title="PAX schema version">schema {{ . }}</div>{{ end }}
       </div>
 
       {{/* Col 5: content-type counts */}}

--- a/themes/pax-terminal/layouts/pax/single.html
+++ b/themes/pax-terminal/layouts/pax/single.html
@@ -227,6 +227,7 @@
           {{ end }}
           <div class="t-meta-kv"><span class="t-kv-label">pax type</span><span class="t-kv-value">{{ $paxType }}</span></div>
           <div class="t-meta-kv"><span class="t-kv-label">version</span><span class="t-kv-value" style="font-variant-numeric:tabular-nums;">{{ $version }}</span></div>
+          {{ with .Params.pax_schema_version }}<div class="t-meta-kv"><span class="t-kv-label">schema</span><span class="t-kv-value" style="font-variant-numeric:tabular-nums;">{{ . }}</span></div>{{ end }}
           {{ with .Params.published_by }}<div class="t-meta-kv"><span class="t-kv-label">published by</span><span class="t-kv-value">{{ . }}</span></div>{{ end }}
           {{ with .Params.download_size }}<div class="t-meta-kv"><span class="t-kv-label">archive</span><span class="t-kv-value" style="font-variant-numeric:tabular-nums;">{{ . }}</span></div>{{ end }}
         </div>


### PR DESCRIPTION
## Summary
The /guide/ page now reflects the canonical spec status pulled directly from `PAX_CREATION_GUIDE.md`:

- **Schema version + last-updated date** rendered prominently at the top.
- **"What's New in v3"** bullets parsed out of the guide and shown inline (collapsible). Markdown formatting (italics, code) is preserved.
- **Registry mix** — how many packs are on each schema version (e.g. v1.0 ×10, v2.0 ×2, v3.0 ×2) so the adoption picture is immediate.
- **Pack list + detail** got a small `schema 3.0` chip next to the pack version so users can spot at a glance which packs are on the current spec.

`generate-content.py` parses the guide once per build and writes `data/guide_meta.yml`. The Hugo layout reads it via `site.Data.guide_meta`. No content is duplicated — when the canonical guide updates upstream in `pax-market`, the next build picks up the new schema version, date, and bullets automatically.

## Test plan
- [x] `python3 scripts/generate-content.py` runs and writes `data/guide_meta.yml`
- [x] `hugo --minify` succeeds locally
- [x] `/guide/` rendered HTML includes the new spec-status block with correct schema version, date, distribution, and What's New bullets
- [x] `/pax/` list rows show `schema X.Y` chips
- [ ] Visual review on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)